### PR TITLE
Fix blank string parsing

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -54,14 +54,18 @@ exports.parse = function(value) {
         return {};
     }
 
-    value = String(value);
+    value = String(value).trim();
+
+    if (!value) {
+        return {};
+    }
 
     if (value.indexOf(',') > -1) {
         value = lexicalToWestern(value);
     }
 
     var name = {};
-    var tokens = value.match(/\S+/g);
+    var tokens = value.match(/\S+/g) || [];
 
     if (contains(salutations, tokens[0])) {
         name.salutation = tokens.shift();

--- a/test/test.js
+++ b/test/test.js
@@ -159,6 +159,16 @@ describe('Edge Cases', function() {
         assert(name);
         assert.strictEqual(Object.keys(name).length, 0);
     });
+
+    it('empty string', function() {
+        var name = whosit.parse('');
+        assert(name);
+        assert.strictEqual(Object.keys(name).length, 0);
+
+        name = whosit.parse('   ');
+        assert(name);
+        assert.strictEqual(Object.keys(name).length, 0);
+    });
 });
 
 describe('Complex Surnames', function() {


### PR DESCRIPTION
## Summary
- handle empty strings gracefully in `parse`
- test parsing of blank strings

## Testing
- `npm test` *(fails: `mocha` not found)*