### PR TITLE
Send Slack notification per matrix run

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,16 +52,12 @@ jobs:
           true
         fi
 
-  notify_slack:
-    if: always()
-    runs-on: ubuntu-latest
-    needs: test
-    steps:
     - name: Notify Slack
+      if: always()
       uses: homoluctus/slatify@master
       with:
-        type: ${{ needs.test.result }}
-        job_name: '${{ github.repository }} - Tests '
+        type: ${{ job.status }}
+        job_name: '${{ github.repository }} - Tests (${{ matrix.node-version }})'
         channel: '#whosit'
         url: ${{ secrets.SLACK_WEBHOOK_URL }}
         commit: true


### PR DESCRIPTION
## Summary
- drop the separate `notify_slack` job
- add `Notify Slack` step to the `test` job so each matrix run posts results individually

## Testing
- `npm test`