### PR TITLE
Add test for comma-only input

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -67,7 +67,7 @@ exports.parse = function(value) {
     const name = {};
     const tokens = value.match(/\S+/g) || [];
 
-    if (contains(salutations, tokens[0])) {
+    if (tokens[0] && contains(salutations, tokens[0])) {
         name.salutation = tokens.shift();
 
         // If there's only one token remaining it's the last name (Mister Rogers)

--- a/test/test.js
+++ b/test/test.js
@@ -170,6 +170,16 @@ describe('Edge Cases', function() {
         assert(name);
         assert.strictEqual(Object.keys(name).length, 0);
     });
+
+    it('single comma', function() {
+        let name = whosit.parse(',');
+        assert(name);
+        assert.strictEqual(Object.keys(name).length, 0);
+
+        name = whosit.parse(' , ');
+        assert(name);
+        assert.strictEqual(Object.keys(name).length, 0);
+    });
 });
 
 describe('Complex Surnames', function() {


### PR DESCRIPTION
## Summary
- cover the tokenization fallback with a new test for comma-only input
- avoid failing when tokens array is empty

## Testing
- `npm test`