### PR TITLE
Normalize dependency version ranges to tilde

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
     "description": "A personal name parser for Node.js: http://en.wikipedia.org/wiki/Personal_name",
     "devDependencies": {
-        "@eslint/js": "*",
-        "globals": "*"
+        "@eslint/js": "~10.0.1",
+        "globals": "~17.6.0"
     },
     "keywords": [
         "name",


### PR DESCRIPTION
Pin the `*` devDependencies to `~` ranges at their currently installed versions, per the fleet standard of tilde-only version ranges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)