### PR TITLE
Restore * devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
     "description": "A personal name parser for Node.js: http://en.wikipedia.org/wiki/Personal_name",
     "devDependencies": {
-        "@eslint/js": "~10.0.1",
-        "globals": "~17.6.0"
+        "@eslint/js": "*",
+        "globals": "*"
     },
     "keywords": [
         "name",


### PR DESCRIPTION
Reverts the devDependencies portion of the tilde normalization — the `~` standard applies to `dependencies` only; devDependencies keep floating `*` ranges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)